### PR TITLE
Upgrade Cake to 0.17.0

### DIFF
--- a/src/Cake.NSwag/Cake.NSwag.csproj
+++ b/src/Cake.NSwag/Cake.NSwag.csproj
@@ -32,8 +32,8 @@
     <DocumentationFile>Cake.NSwag.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.15.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.15.2\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/Cake.NSwag/packages.config
+++ b/src/Cake.NSwag/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.15.2" targetFramework="net452" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NJsonSchema" version="4.8.6094.34027" targetFramework="net452" />
   <package id="NJsonSchema.CodeGeneration" version="4.8.6094.34028" targetFramework="net452" />


### PR DESCRIPTION
Cake 0.18.0 will requires at least version 0.16.x to work.