### PR TITLE
Add ability to generate swagger.json from .exe assembly

### DIFF
--- a/src/Cake.NSwag/NSwagRunner.cs
+++ b/src/Cake.NSwag/NSwagRunner.cs
@@ -56,7 +56,7 @@ namespace Cake.NSwag
             {
                 throw new FileNotFoundException($"Could not find file '{assemblyPath}", nameof(assemblyPath));
             }
-            if (assemblyPath.HasExtension && !assemblyPath.GetExtension().Contains("dll"))
+            if (assemblyPath.HasExtension && !(assemblyPath.GetExtension().Contains("dll") || assemblyPath.GetExtension().Contains("exe")))
             {
                 throw new ArgumentException($"The '{assemblyPath}' does not appear to be an assembly!",
                     nameof(assemblyPath));


### PR DESCRIPTION
In self-hosted situations the controllers may be in an assembly with .exe extension.